### PR TITLE
Change jsonData in _iterPost to setdefault

### DIFF
--- a/birdsong/rest.py
+++ b/birdsong/rest.py
@@ -97,7 +97,7 @@ class RestInterface(object):
                     yield item
             else:
                 yield results
-            jsonData['continuation'] = self.lastResults['continuation']
+            jsonData.setdefault('continuation', self.lastResults['continuation'])
             self._post(apiUrl, jsonData)
             self._raiseUnhandledPostError(apiUrl, jsonData)
         else:

--- a/birdsong/rest.py
+++ b/birdsong/rest.py
@@ -97,7 +97,10 @@ class RestInterface(object):
                     yield item
             else:
                 yield results
-            jsonData.setdefault('continuation', self.lastResults['continuation'])
+            if 'continuation' in jsonData:
+                jsonData['continuation'] = self.lastResults['continuation']
+            else:
+                jsonData.setdefault('continuation', self.lastResults['continuation'])
             self._post(apiUrl, jsonData)
             self._raiseUnhandledPostError(apiUrl, jsonData)
         else:


### PR DESCRIPTION
Update jsonData continuation key setting to setdefault in case continuation does not exist as a key already, fixing KeyError

Also sorry if noob, still learning. Finally back into python after a year and a half of bathing in SQL for a different position